### PR TITLE
Prevent crashing when splitting text with usupported characters

### DIFF
--- a/contrib/barcode/barcode.go
+++ b/contrib/barcode/barcode.go
@@ -34,7 +34,7 @@ import (
 	"github.com/boombuler/barcode/ean"
 	"github.com/boombuler/barcode/qr"
 	"github.com/boombuler/barcode/twooffive"
-	"github.com/phpdave11/gofpdf"
+	"github.com/gonzaloserrano/gofpdf"
 	"github.com/ruudk/golang-pdf417"
 )
 

--- a/contrib/barcode/barcode_test.go
+++ b/contrib/barcode/barcode_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/boombuler/barcode/code128"
 	"github.com/boombuler/barcode/qr"
-	"github.com/phpdave11/gofpdf"
-	"github.com/phpdave11/gofpdf/contrib/barcode"
-	"github.com/phpdave11/gofpdf/internal/example"
+	"github.com/gonzaloserrano/gofpdf"
+	"github.com/gonzaloserrano/gofpdf/contrib/barcode"
+	"github.com/gonzaloserrano/gofpdf/internal/example"
 )
 
 func createPdf() (pdf *gofpdf.Fpdf) {

--- a/contrib/ghostscript/ghostscript.go
+++ b/contrib/ghostscript/ghostscript.go
@@ -2,14 +2,14 @@ package main
 
 // This command demonstrates the use of ghotscript to reduce the size
 // of generated PDFs. This is based on a comment made by farkerhaiku:
-// https://github.com/phpdave11/gofpdf/issues/57#issuecomment-185843315
+// https://github.com/gonzaloserrano/gofpdf/issues/57#issuecomment-185843315
 
 import (
 	"fmt"
 	"os"
 	"os/exec"
 
-	"github.com/phpdave11/gofpdf"
+	"github.com/gonzaloserrano/gofpdf"
 )
 
 func report(fileStr string, err error) {

--- a/contrib/gofpdi/gofpdi.go
+++ b/contrib/gofpdi/gofpdi.go
@@ -9,8 +9,9 @@ however that use of the default Importer is not thread safe.
 package gofpdi
 
 import (
-	realgofpdi "github.com/phpdave11/gofpdi"
 	"io"
+
+	realgofpdi "github.com/phpdave11/gofpdi"
 )
 
 // gofpdiPdf is a partial interface that only implements the functions we need

--- a/contrib/gofpdi/gofpdi_test.go
+++ b/contrib/gofpdi/gofpdi_test.go
@@ -2,8 +2,8 @@ package gofpdi
 
 import (
 	"bytes"
-	"github.com/phpdave11/gofpdf"
-	"github.com/phpdave11/gofpdf/internal/example"
+	"github.com/gonzaloserrano/gofpdf"
+	"github.com/gonzaloserrano/gofpdf/internal/example"
 	"io"
 	"sync"
 	"testing"

--- a/contrib/httpimg/httpimg.go
+++ b/contrib/httpimg/httpimg.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/phpdave11/gofpdf"
+	"github.com/gonzaloserrano/gofpdf"
 )
 
 // httpimgPdf is a partial interface that only implements the functions we need

--- a/contrib/httpimg/httpimg_test.go
+++ b/contrib/httpimg/httpimg_test.go
@@ -1,9 +1,9 @@
 package httpimg_test
 
 import (
-	"github.com/phpdave11/gofpdf"
-	"github.com/phpdave11/gofpdf/contrib/httpimg"
-	"github.com/phpdave11/gofpdf/internal/example"
+	"github.com/gonzaloserrano/gofpdf"
+	"github.com/gonzaloserrano/gofpdf/contrib/httpimg"
+	"github.com/gonzaloserrano/gofpdf/internal/example"
 )
 
 func ExampleRegister() {
@@ -12,7 +12,7 @@ func ExampleRegister() {
 	pdf.SetFillColor(200, 200, 220)
 	pdf.AddPage()
 
-	url := "https://github.com/phpdave11/gofpdf/raw/master/image/logo_gofpdf.jpg?raw=true"
+	url := "https://github.com/gonzaloserrano/gofpdf/raw/master/image/logo_gofpdf.jpg?raw=true"
 	httpimg.Register(pdf, url, "")
 	pdf.Image(url, 15, 15, 267, 0, false, "", 0, "")
 	fileStr := example.Filename("contrib_httpimg_Register")

--- a/contrib/tiff/tiff.go
+++ b/contrib/tiff/tiff.go
@@ -26,7 +26,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/phpdave11/gofpdf"
+	"github.com/gonzaloserrano/gofpdf"
 	"golang.org/x/image/tiff"
 )
 

--- a/contrib/tiff/tiff_test.go
+++ b/contrib/tiff/tiff_test.go
@@ -1,9 +1,9 @@
 package tiff_test
 
 import (
-	"github.com/phpdave11/gofpdf"
-	"github.com/phpdave11/gofpdf/contrib/tiff"
-	"github.com/phpdave11/gofpdf/internal/example"
+	"github.com/gonzaloserrano/gofpdf"
+	"github.com/gonzaloserrano/gofpdf/contrib/tiff"
+	"github.com/gonzaloserrano/gofpdf/internal/example"
 )
 
 // ExampleRegisterFile demonstrates the loading and display of a TIFF image.

--- a/doc.go
+++ b/doc.go
@@ -78,11 +78,11 @@ Installation
 
 To install the package on your system, run
 
-    go get github.com/phpdave11/gofpdf
+    go get github.com/gonzaloserrano/gofpdf
 
 Later, to receive updates, run
 
-    go get -u -v github.com/phpdave11/gofpdf/...
+    go get -u -v github.com/gonzaloserrano/gofpdf/...
 
 
 Quick Start

--- a/fpdf_test.go
+++ b/fpdf_test.go
@@ -32,9 +32,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/phpdave11/gofpdf"
-	"github.com/phpdave11/gofpdf/internal/example"
-	"github.com/phpdave11/gofpdf/internal/files"
+	"github.com/gonzaloserrano/gofpdf"
+	"github.com/gonzaloserrano/gofpdf/internal/example"
+	"github.com/gonzaloserrano/gofpdf/internal/files"
 )
 
 func init() {
@@ -1568,7 +1568,7 @@ func ExampleFpdf_CellFormat_align() {
 				pdf.CellFormat(170, 257, rec.txt, borderStr, 0, rec.align, false, 0, linkStr)
 				borderStr = ""
 			}
-			linkStr = "https://github.com/phpdave11/gofpdf"
+			linkStr = "https://github.com/gonzaloserrano/gofpdf"
 		}
 	}
 	pdf := gofpdf.New("P", "mm", "A4", "") // A4 210.0 x 297.0
@@ -1776,7 +1776,7 @@ func ExampleFpdf_RegisterImageReader() {
 		wd       = 210
 		ht       = 297
 		fontSize = 15
-		urlStr   = "https://github.com/phpdave11/gofpdf/blob/master/image/gofpdf.png?raw=true"
+		urlStr   = "https://github.com/gonzaloserrano/gofpdf/blob/master/image/gofpdf.png?raw=true"
 		msgStr   = `Images from the web can be easily embedded when a PDF document is generated.`
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/phpdave11/gofpdf
+module github.com/gonzaloserrano/gofpdf
 
 go 1.12
 

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,7 @@ github.com/phpdave11/gofpdi v1.0.11 h1:wsBNx+3S0wy1dEp6fzv281S74ogZGgIdYWV2PugWg
 github.com/phpdave11/gofpdi v1.0.11/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
 github.com/phpdave11/gofpdi v1.0.12 h1:RZb9NG62cw/RW0rHAduVRo+98R8o/G1krcg2ns7DakQ=
 github.com/phpdave11/gofpdi v1.0.12/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
+github.com/phpdave11/gofpdi v1.0.13 h1:o61duiW8M9sMlkVXWlvP92sZJtGKENvW3VExs6dZukQ=
 github.com/phpdave11/gofpdi v1.0.13/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/example/example.go
+++ b/internal/example/example.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/phpdave11/gofpdf"
+	"github.com/gonzaloserrano/gofpdf"
 )
 
 var gofpdfDir string

--- a/internal/example/example_test.go
+++ b/internal/example/example_test.go
@@ -19,7 +19,7 @@ package example_test
 import (
 	"errors"
 
-	"github.com/phpdave11/gofpdf/internal/example"
+	"github.com/gonzaloserrano/gofpdf/internal/example"
 )
 
 // ExampleFilename tests the Filename() and Summary() functions.

--- a/makefont/makefont.go
+++ b/makefont/makefont.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/phpdave11/gofpdf"
+	"github.com/gonzaloserrano/gofpdf"
 	"os"
 )
 

--- a/splittext.go
+++ b/splittext.go
@@ -25,6 +25,10 @@ func (f *Fpdf) SplitText(txt string, w float64) (lines []string) {
 	l := 0
 	for i < nb {
 		c := s[i]
+		if int(c) >= len(cw) {
+			i++
+			continue
+		}
 		l += cw[c]
 		if unicode.IsSpace(c) || isChinese(c) {
 			sep = i

--- a/ttfparser_test.go
+++ b/ttfparser_test.go
@@ -20,8 +20,8 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/phpdave11/gofpdf"
-	"github.com/phpdave11/gofpdf/internal/example"
+	"github.com/gonzaloserrano/gofpdf"
+	"github.com/gonzaloserrano/gofpdf/internal/example"
 )
 
 func ExampleTtfParse() {


### PR DESCRIPTION
Didn't have time to do a proper test but this fixes splitting lines when using for e.g emojis. 

It's similar to this fix https://github.com/phpdave11/gofpdf/commit/c4685a7728b6292626d70215c8d5e9c28aefe075