### PR TITLE
Prevent crashing when splitting text with usupported characters

### DIFF
--- a/splittext.go
+++ b/splittext.go
@@ -25,6 +25,10 @@ func (f *Fpdf) SplitText(txt string, w float64) (lines []string) {
 	l := 0
 	for i < nb {
 		c := s[i]
+		if int(c) >= len(cw) {
+			i++
+			continue
+		}
 		l += cw[c]
 		if unicode.IsSpace(c) || isChinese(c) {
 			sep = i


### PR DESCRIPTION
Didn't have time to do a proper test but this fixes splitting lines when using for e.g emojis.

It's similar to this fix c4685a7