### PR TITLE
Add SetCellStretchToFit() and ResetCellStretch functions

### DIFF
--- a/fpdf.go
+++ b/fpdf.go
@@ -348,6 +348,20 @@ func (f *Fpdf) SetCellMargin(margin float64) {
 	f.cMargin = margin
 }
 
+// SetCellStretchToFit sets the horizontal stretch to fit the entireity
+// of some text into of a cell of a given width.
+func (f *Fpdf) SetCellStretchToFit(w float64, txtStr string) {
+	stringW := f.GetStringWidth(txtStr)
+	margin := f.GetCellMargin()
+	ratio := (w - margin * 2) / stringW
+	f.outf("BT %.0f Tz ET", ratio * 100)
+}
+
+// ResetCellStretch resets the horizontal stretch to the default.
+func (f *Fpdf) ResetCellStretch(w float64, txtStr string) {
+	f.outf("BT 100 Tz ET")
+}
+
 // SetPageBoxRec sets the page box for the current page, and any following
 // pages. Allowable types are trim, trimbox, crop, cropbox, bleed, bleedbox,
 // art and artbox box types are case insensitive. See SetPageBox() for a method


### PR DESCRIPTION
The SetCellStretchToFit function can be used to set horizontal stretching
of text to fit the full width of a cell. This is particularly useful when
trying to precisely line up text in a cell with an OCR image below it, and
as a pleasant side-effect can also prevent PDF readers from assuming that
words in cells on the same line with some space between them are in fact on
different lines when copy-pasting the text.

The ResetCellStretch function resets the cell stretch value to the default,
which is no stretch (100%).

This uses the Tz text state operator described in section 9.3.1 of the PDF 3200-1:2008 specification.

An alternative (php) implementation <http://www.fpdf.org/en/script/script62.php> wraps the Cell() method instead, but I prefer the stateful approach here, as it's cleaner and simpler.

This is super useful for me in creating searchable PDFs from page images (using invisible text), as it means I can set the text in each Cell to take the whole space allocated, and as the OCR engine gives the exact size of each text box this makes the whole thing very accurate.