### PR TITLE
fix handing of svg paths with negative values and no delimiter

### DIFF
--- a/svgbasic.go
+++ b/svgbasic.go
@@ -28,7 +28,8 @@ var pathCmdSub *strings.Replacer
 
 func init() {
 	// Handle permitted constructions like "100L200,230"
-	pathCmdSub = strings.NewReplacer(",", " ",
+	pathCmdSub = strings.NewReplacer(
+		",", " ", "-", " -",
 		"L", " L ", "l", " l ",
 		"C", " C ", "c", " c ",
 		"M", " M ", "m", " m ",


### PR DESCRIPTION
fixes handling of permitted svg path constructions like c7.9-1.71,23.27-6.46,34.8-8.07