### PR TITLE
Update splittext.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/phpdave11/gofpdf
+module github.com/adamjack/gofpdf
 
 go 1.12
 


### PR DESCRIPTION
More carefully inspect the font for "character width" for each character (rune) and do not crash if the font does not have a width for the character.

I was receiving this crash on line 28 when the string contained a single right apostrophe:

           panic: runtime error: index out of range [8217] with length 256

P.S. I am no expert but as I was looking around the utf8File seemed a reasonable place to look for more widths.

If it cannot find a width for the character it uses a placeholder, using underscore 'cos "wider seemed safer".